### PR TITLE
fix ElastiCacheEnable description

### DIFF
--- a/templates/drupal.template
+++ b/templates/drupal.template
@@ -523,7 +523,7 @@
                 "false"
             ],
             "Default": "true",
-            "Description": "Enable CloudFront Content Delivery Network",
+            "Description": "Enable ElastiCache",
             "Type": "String"
         },
         "ElastiCacheAutoMinorVersionUpgrade":{


### PR DESCRIPTION
Changes the `ElastiCacheEnable` description to mention ElastiCache instead of Cloudfront